### PR TITLE
Add missing Package-Requires

### DIFF
--- a/ellellemm.el
+++ b/ellellemm.el
@@ -4,7 +4,7 @@
 
 ;; Author: Deepankar Sharma <deepankarsharma@gmail.com>
 ;; Version: 1.0
-;; Package-Requires: ((emacs "24.3") (plz "3.18.01") (poly-markdown "0.2.2"))
+;; Package-Requires: ((emacs "24.3") (plz "3.18.01"))
 ;; Keywords: llm, productivity
 ;; URL: https://github.com/deepankarsharma/ellellemm
 
@@ -53,7 +53,7 @@
         (let
             ((buffer (generate-new-buffer buffer-name)))
           (with-current-buffer "*ellellemm-buffer*"
-            (poly-markdown-mode))
+            (markdown-mode))
           buffer))))
 
 (defun insert-line-separator ()

--- a/ellellemm.el
+++ b/ellellemm.el
@@ -4,7 +4,7 @@
 
 ;; Author: Deepankar Sharma <deepankarsharma@gmail.com>
 ;; Version: 1.0
-;; Package-Requires: ((emacs "24.3"))
+;; Package-Requires: ((emacs "24.3") (plz "3.18.01") (poly-markdown "0.2.2"))
 ;; Keywords: llm, productivity
 ;; URL: https://github.com/deepankarsharma/ellellemm
 


### PR DESCRIPTION
Add `plz` as Package-Requires, without it declared I was not able to use this package given that I did not have the package installed.

Use `mark-down-mode` instead of `poly-markdown-mode` not to require `poly-markdown` as additional dependency.